### PR TITLE
Fix re-renders

### DIFF
--- a/build/cjs/reTheme.native.js
+++ b/build/cjs/reTheme.native.js
@@ -202,6 +202,75 @@ var joinTheme = function joinTheme(arg1, arg2) {
   })).concat(sources)) : getTheme.apply(void 0, [arg1, arg2].concat(sources));
 };
 
+var convertToPercent = function convertToPercent(num, percent) {
+  return parseInt(num * (100 + percent) / 100);
+};
+var checkColorMax = function checkColorMax(num) {
+  return num < 255 ? num : 255;
+};
+var convertToColor = function convertToColor(num, percent) {
+  var asPercent = convertToPercent(num, percent);
+  var withMax = checkColorMax(asPercent);
+  var asStr = withMax.toString(16);
+  return asStr.length == 1 ? "0".concat(asStr) : asStr;
+};
+var mapOpacity = function mapOpacity(opacity) {
+  for (var amount = 100; amount >= 0; amount -= 5) {
+    opacity["_".concat(amount)] = opacity((amount / 100).toFixed(2));
+  }
+  return opacity;
+};
+var hexToRgba = function hexToRgba(hex, opacity, asObj) {
+  if (!hex) return console.warn('Can not convert hex to rgba', hex) || "rgba(255,255,255,0)";
+  hex = hex.indexOf('#') === 0 ? hex.replace('#', '') : hex;
+  opacity = opacity > 1 ? (opacity / 100).toFixed(4) : opacity;
+  var rgbaObj = {
+    r: parseInt(hex.substring(0, 2), 16),
+    g: parseInt(hex.substring(2, 4), 16),
+    b: parseInt(hex.substring(4, 6), 16),
+    a: !opacity && opacity !== 0 ? 1 : opacity
+  };
+  return asObj ? rgbaObj : toRgb(rgbaObj);
+};
+var opacity = mapOpacity(function (amount, color) {
+  return jsutils.isStr(color) && color.indexOf('#') === 0 ? hexToRgba(color, amount) : jsutils.isObj(color) ? toRgb(color, amount) : "rgba(".concat(color || '0,0,0', ", ").concat(amount, ")");
+});
+var shadeHex = function shadeHex(color, percent) {
+  var rgba = hexToRgba(color, 1, true);
+  return "#" + convertToColor(rgba.r, percent) + convertToColor(rgba.g, percent) + convertToColor(rgba.b, percent);
+};
+var toRgb = function toRgb(red, green, blue, alpha) {
+  var obj = jsutils.isObj(red) ? red : {
+    r: red,
+    g: green,
+    b: blue,
+    a: alpha
+  };
+  obj.a = !obj.a && obj.a !== 0 ? 1 : obj.a;
+  return "rgba(".concat(obj.r, ", ").concat(obj.g, ", ").concat(obj.b, ", ").concat(obj.a, ")");
+};
+var transition = function transition() {
+  var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+  var speed = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 250;
+  var timingFunc = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'ease';
+  return typeof props === 'string' ? "".concat(props, " ").concat(speed, "ms ").concat(timingFunc) : jsutils.isArr(props) ? props.reduce(function (trans, prop) {
+    trans.push("".concat(prop, " ").concat(speed, "ms ").concat(timingFunc));
+    return trans;
+  }, []).join(', ') : null;
+};
+
+var colors = /*#__PURE__*/Object.freeze({
+  hexToRgba: hexToRgba,
+  opacity: opacity,
+  shadeHex: shadeHex,
+  toRgb: toRgb,
+  transition: transition
+});
+
+var helpers = {
+  colors: colors
+};
+
 var Constants = jsutils.deepFreeze({
   BUILD_EVENT: 'build',
   CHANGE_EVENT: 'change',
@@ -436,10 +505,6 @@ var ReThemeProvider = function ReThemeProvider(props) {
       _useState2 = _slicedToArray(_useState, 2),
       dimensions = _useState2[0],
       setDimensions = _useState2[1];
-  var _useState3 = React.useState(false),
-      _useState4 = _slicedToArray(_useState3, 2),
-      hasListener = _useState4[0],
-      setListener = _useState4[1];
   var onChange = function onChange(_ref) {
     var win = _ref.window;
     var width = win.width,
@@ -458,11 +523,8 @@ var ReThemeProvider = function ReThemeProvider(props) {
     });
   };
   React.useEffect(function () {
-    if (!hasListener) {
-      Dimensions.addEventListener("change", onChange);
-      addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
-      setListener(true);
-    }
+    Dimensions.addEventListener("change", onChange);
+    addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
     return function () {
       Dimensions.removeEventListener("change", onChange);
       removeThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
@@ -498,6 +560,7 @@ exports.getDefaultTheme = getDefaultTheme;
 exports.getMergeSizes = getMergeSizes;
 exports.getSize = getSize;
 exports.getSizeMap = getSizeMap;
+exports.helpers = helpers;
 exports.removeThemeEvent = removeThemeEvent;
 exports.setDefaultTheme = setDefaultTheme;
 exports.setRNDimensions = setRNDimensions;

--- a/build/cjs/reTheme.native.js
+++ b/build/cjs/reTheme.native.js
@@ -543,12 +543,18 @@ var useTheme = function useTheme() {
   return theme;
 };
 
+var checkEqual = function checkEqual(obj1, obj2) {
+  return obj1 === obj2 || jsutils.jsonEqual(obj1, obj2);
+};
 var nativeThemeHook = function nativeThemeHook(offValue, onValue, options) {
   var hookRef = jsutils.get(options, 'ref', React.useRef());
   var _useState = React.useState(offValue),
       _useState2 = _slicedToArray(_useState, 2),
       value = _useState2[0],
       setValue = _useState2[1];
+  React.useLayoutEffect(function () {
+    !checkEqual(offValue, value) && setValue(value);
+  }, [offValue, onValue]);
   return [hookRef, offValue, setValue];
 };
 

--- a/build/cjs/reTheme.web.js
+++ b/build/cjs/reTheme.web.js
@@ -267,6 +267,75 @@ var joinTheme = function joinTheme(arg1, arg2) {
   })).concat(sources)) : getTheme.apply(void 0, [arg1, arg2].concat(sources));
 };
 
+var convertToPercent = function convertToPercent(num, percent) {
+  return parseInt(num * (100 + percent) / 100);
+};
+var checkColorMax = function checkColorMax(num) {
+  return num < 255 ? num : 255;
+};
+var convertToColor = function convertToColor(num, percent) {
+  var asPercent = convertToPercent(num, percent);
+  var withMax = checkColorMax(asPercent);
+  var asStr = withMax.toString(16);
+  return asStr.length == 1 ? "0".concat(asStr) : asStr;
+};
+var mapOpacity = function mapOpacity(opacity) {
+  for (var amount = 100; amount >= 0; amount -= 5) {
+    opacity["_".concat(amount)] = opacity((amount / 100).toFixed(2));
+  }
+  return opacity;
+};
+var hexToRgba = function hexToRgba(hex, opacity, asObj) {
+  if (!hex) return console.warn('Can not convert hex to rgba', hex) || "rgba(255,255,255,0)";
+  hex = hex.indexOf('#') === 0 ? hex.replace('#', '') : hex;
+  opacity = opacity > 1 ? (opacity / 100).toFixed(4) : opacity;
+  var rgbaObj = {
+    r: parseInt(hex.substring(0, 2), 16),
+    g: parseInt(hex.substring(2, 4), 16),
+    b: parseInt(hex.substring(4, 6), 16),
+    a: !opacity && opacity !== 0 ? 1 : opacity
+  };
+  return asObj ? rgbaObj : toRgb(rgbaObj);
+};
+var opacity = mapOpacity(function (amount, color) {
+  return jsutils.isStr(color) && color.indexOf('#') === 0 ? hexToRgba(color, amount) : jsutils.isObj(color) ? toRgb(color, amount) : "rgba(".concat(color || '0,0,0', ", ").concat(amount, ")");
+});
+var shadeHex = function shadeHex(color, percent) {
+  var rgba = hexToRgba(color, 1, true);
+  return "#" + convertToColor(rgba.r, percent) + convertToColor(rgba.g, percent) + convertToColor(rgba.b, percent);
+};
+var toRgb = function toRgb(red, green, blue, alpha) {
+  var obj = jsutils.isObj(red) ? red : {
+    r: red,
+    g: green,
+    b: blue,
+    a: alpha
+  };
+  obj.a = !obj.a && obj.a !== 0 ? 1 : obj.a;
+  return "rgba(".concat(obj.r, ", ").concat(obj.g, ", ").concat(obj.b, ", ").concat(obj.a, ")");
+};
+var transition = function transition() {
+  var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+  var speed = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 250;
+  var timingFunc = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'ease';
+  return typeof props === 'string' ? "".concat(props, " ").concat(speed, "ms ").concat(timingFunc) : jsutils.isArr(props) ? props.reduce(function (trans, prop) {
+    trans.push("".concat(prop, " ").concat(speed, "ms ").concat(timingFunc));
+    return trans;
+  }, []).join(', ') : null;
+};
+
+var colors = /*#__PURE__*/Object.freeze({
+  hexToRgba: hexToRgba,
+  opacity: opacity,
+  shadeHex: shadeHex,
+  toRgb: toRgb,
+  transition: transition
+});
+
+var helpers = {
+  colors: colors
+};
+
 var sizeMap = {
   entries: [['xsmall', 1], ['small', 320], ['medium', 768], ['large', 1024], ['xlarge', 1366]],
   hash: {},
@@ -490,10 +559,6 @@ var ReThemeProvider = function ReThemeProvider(props) {
       _useState2 = _slicedToArray(_useState, 2),
       dimensions = _useState2[0],
       setDimensions = _useState2[1];
-  var _useState3 = React.useState(false),
-      _useState4 = _slicedToArray(_useState3, 2),
-      hasListener = _useState4[0],
-      setListener = _useState4[1];
   var onChange = function onChange(_ref) {
     var win = _ref.window;
     var width = win.width,
@@ -512,11 +577,8 @@ var ReThemeProvider = function ReThemeProvider(props) {
     });
   };
   React.useEffect(function () {
-    if (!hasListener) {
-      Dimensions.addEventListener("change", onChange);
-      addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
-      setListener(true);
-    }
+    Dimensions.addEventListener("change", onChange);
+    addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
     return function () {
       Dimensions.removeEventListener("change", onChange);
       removeThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
@@ -632,6 +694,7 @@ exports.getDefaultTheme = getDefaultTheme;
 exports.getMergeSizes = getMergeSizes;
 exports.getSize = getSize;
 exports.getSizeMap = getSizeMap;
+exports.helpers = helpers;
 exports.removeThemeEvent = removeThemeEvent;
 exports.setDefaultTheme = setDefaultTheme;
 exports.setRNDimensions = setRNDimensions;

--- a/build/esm/reTheme.native.js
+++ b/build/esm/reTheme.native.js
@@ -195,6 +195,75 @@ var joinTheme = function joinTheme(arg1, arg2) {
   })).concat(sources)) : getTheme.apply(void 0, [arg1, arg2].concat(sources));
 };
 
+var convertToPercent = function convertToPercent(num, percent) {
+  return parseInt(num * (100 + percent) / 100);
+};
+var checkColorMax = function checkColorMax(num) {
+  return num < 255 ? num : 255;
+};
+var convertToColor = function convertToColor(num, percent) {
+  var asPercent = convertToPercent(num, percent);
+  var withMax = checkColorMax(asPercent);
+  var asStr = withMax.toString(16);
+  return asStr.length == 1 ? "0".concat(asStr) : asStr;
+};
+var mapOpacity = function mapOpacity(opacity) {
+  for (var amount = 100; amount >= 0; amount -= 5) {
+    opacity["_".concat(amount)] = opacity((amount / 100).toFixed(2));
+  }
+  return opacity;
+};
+var hexToRgba = function hexToRgba(hex, opacity, asObj) {
+  if (!hex) return console.warn('Can not convert hex to rgba', hex) || "rgba(255,255,255,0)";
+  hex = hex.indexOf('#') === 0 ? hex.replace('#', '') : hex;
+  opacity = opacity > 1 ? (opacity / 100).toFixed(4) : opacity;
+  var rgbaObj = {
+    r: parseInt(hex.substring(0, 2), 16),
+    g: parseInt(hex.substring(2, 4), 16),
+    b: parseInt(hex.substring(4, 6), 16),
+    a: !opacity && opacity !== 0 ? 1 : opacity
+  };
+  return asObj ? rgbaObj : toRgb(rgbaObj);
+};
+var opacity = mapOpacity(function (amount, color) {
+  return isStr(color) && color.indexOf('#') === 0 ? hexToRgba(color, amount) : isObj(color) ? toRgb(color, amount) : "rgba(".concat(color || '0,0,0', ", ").concat(amount, ")");
+});
+var shadeHex = function shadeHex(color, percent) {
+  var rgba = hexToRgba(color, 1, true);
+  return "#" + convertToColor(rgba.r, percent) + convertToColor(rgba.g, percent) + convertToColor(rgba.b, percent);
+};
+var toRgb = function toRgb(red, green, blue, alpha) {
+  var obj = isObj(red) ? red : {
+    r: red,
+    g: green,
+    b: blue,
+    a: alpha
+  };
+  obj.a = !obj.a && obj.a !== 0 ? 1 : obj.a;
+  return "rgba(".concat(obj.r, ", ").concat(obj.g, ", ").concat(obj.b, ", ").concat(obj.a, ")");
+};
+var transition = function transition() {
+  var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+  var speed = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 250;
+  var timingFunc = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'ease';
+  return typeof props === 'string' ? "".concat(props, " ").concat(speed, "ms ").concat(timingFunc) : isArr(props) ? props.reduce(function (trans, prop) {
+    trans.push("".concat(prop, " ").concat(speed, "ms ").concat(timingFunc));
+    return trans;
+  }, []).join(', ') : null;
+};
+
+var colors = /*#__PURE__*/Object.freeze({
+  hexToRgba: hexToRgba,
+  opacity: opacity,
+  shadeHex: shadeHex,
+  toRgb: toRgb,
+  transition: transition
+});
+
+var helpers = {
+  colors: colors
+};
+
 var Constants = deepFreeze({
   BUILD_EVENT: 'build',
   CHANGE_EVENT: 'change',
@@ -429,10 +498,6 @@ var ReThemeProvider = function ReThemeProvider(props) {
       _useState2 = _slicedToArray(_useState, 2),
       dimensions = _useState2[0],
       setDimensions = _useState2[1];
-  var _useState3 = useState(false),
-      _useState4 = _slicedToArray(_useState3, 2),
-      hasListener = _useState4[0],
-      setListener = _useState4[1];
   var onChange = function onChange(_ref) {
     var win = _ref.window;
     var width = win.width,
@@ -451,11 +516,8 @@ var ReThemeProvider = function ReThemeProvider(props) {
     });
   };
   useEffect(function () {
-    if (!hasListener) {
-      Dimensions.addEventListener("change", onChange);
-      addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
-      setListener(true);
-    }
+    Dimensions.addEventListener("change", onChange);
+    addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
     return function () {
       Dimensions.removeEventListener("change", onChange);
       removeThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
@@ -483,4 +545,4 @@ var nativeThemeHook = function nativeThemeHook(offValue, onValue, options) {
   return [hookRef, offValue, setValue];
 };
 
-export { ReThemeContext, ReThemeProvider, addThemeEvent, fireThemeEvent, getDefaultTheme, getMergeSizes, getSize, getSizeMap, removeThemeEvent, setDefaultTheme, setRNDimensions, setRNPlatform, setSizes, useDimensions, useTheme, nativeThemeHook as useThemeActive, nativeThemeHook as useThemeFocus, nativeThemeHook as useThemeHover, withTheme };
+export { ReThemeContext, ReThemeProvider, addThemeEvent, fireThemeEvent, getDefaultTheme, getMergeSizes, getSize, getSizeMap, helpers, removeThemeEvent, setDefaultTheme, setRNDimensions, setRNPlatform, setSizes, useDimensions, useTheme, nativeThemeHook as useThemeActive, nativeThemeHook as useThemeFocus, nativeThemeHook as useThemeHover, withTheme };

--- a/build/esm/reTheme.native.js
+++ b/build/esm/reTheme.native.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useContext, useRef } from 'react';
-import { isFunc, isNum, isArr, deepMerge, isObj, isStr, get, deepFreeze, logData, mapObj, softFalsy, toNum, reduceObj, unset, isEmpty } from 'jsutils';
+import React, { useState, useEffect, useContext, useRef, useLayoutEffect } from 'react';
+import { isFunc, isNum, isArr, deepMerge, isObj, isStr, get, deepFreeze, logData, mapObj, softFalsy, toNum, reduceObj, unset, isEmpty, jsonEqual } from 'jsutils';
 
 function _extends() {
   _extends = Object.assign || function (target) {
@@ -536,12 +536,18 @@ var useTheme = function useTheme() {
   return theme;
 };
 
+var checkEqual = function checkEqual(obj1, obj2) {
+  return obj1 === obj2 || jsonEqual(obj1, obj2);
+};
 var nativeThemeHook = function nativeThemeHook(offValue, onValue, options) {
   var hookRef = get(options, 'ref', useRef());
   var _useState = useState(offValue),
       _useState2 = _slicedToArray(_useState, 2),
       value = _useState2[0],
       setValue = _useState2[1];
+  useLayoutEffect(function () {
+    !checkEqual(offValue, value) && setValue(value);
+  }, [offValue, onValue]);
   return [hookRef, offValue, setValue];
 };
 

--- a/build/esm/reTheme.web.js
+++ b/build/esm/reTheme.web.js
@@ -260,6 +260,75 @@ var joinTheme = function joinTheme(arg1, arg2) {
   })).concat(sources)) : getTheme.apply(void 0, [arg1, arg2].concat(sources));
 };
 
+var convertToPercent = function convertToPercent(num, percent) {
+  return parseInt(num * (100 + percent) / 100);
+};
+var checkColorMax = function checkColorMax(num) {
+  return num < 255 ? num : 255;
+};
+var convertToColor = function convertToColor(num, percent) {
+  var asPercent = convertToPercent(num, percent);
+  var withMax = checkColorMax(asPercent);
+  var asStr = withMax.toString(16);
+  return asStr.length == 1 ? "0".concat(asStr) : asStr;
+};
+var mapOpacity = function mapOpacity(opacity) {
+  for (var amount = 100; amount >= 0; amount -= 5) {
+    opacity["_".concat(amount)] = opacity((amount / 100).toFixed(2));
+  }
+  return opacity;
+};
+var hexToRgba = function hexToRgba(hex, opacity, asObj) {
+  if (!hex) return console.warn('Can not convert hex to rgba', hex) || "rgba(255,255,255,0)";
+  hex = hex.indexOf('#') === 0 ? hex.replace('#', '') : hex;
+  opacity = opacity > 1 ? (opacity / 100).toFixed(4) : opacity;
+  var rgbaObj = {
+    r: parseInt(hex.substring(0, 2), 16),
+    g: parseInt(hex.substring(2, 4), 16),
+    b: parseInt(hex.substring(4, 6), 16),
+    a: !opacity && opacity !== 0 ? 1 : opacity
+  };
+  return asObj ? rgbaObj : toRgb(rgbaObj);
+};
+var opacity = mapOpacity(function (amount, color) {
+  return isStr(color) && color.indexOf('#') === 0 ? hexToRgba(color, amount) : isObj(color) ? toRgb(color, amount) : "rgba(".concat(color || '0,0,0', ", ").concat(amount, ")");
+});
+var shadeHex = function shadeHex(color, percent) {
+  var rgba = hexToRgba(color, 1, true);
+  return "#" + convertToColor(rgba.r, percent) + convertToColor(rgba.g, percent) + convertToColor(rgba.b, percent);
+};
+var toRgb = function toRgb(red, green, blue, alpha) {
+  var obj = isObj(red) ? red : {
+    r: red,
+    g: green,
+    b: blue,
+    a: alpha
+  };
+  obj.a = !obj.a && obj.a !== 0 ? 1 : obj.a;
+  return "rgba(".concat(obj.r, ", ").concat(obj.g, ", ").concat(obj.b, ", ").concat(obj.a, ")");
+};
+var transition = function transition() {
+  var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+  var speed = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 250;
+  var timingFunc = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'ease';
+  return typeof props === 'string' ? "".concat(props, " ").concat(speed, "ms ").concat(timingFunc) : isArr(props) ? props.reduce(function (trans, prop) {
+    trans.push("".concat(prop, " ").concat(speed, "ms ").concat(timingFunc));
+    return trans;
+  }, []).join(', ') : null;
+};
+
+var colors = /*#__PURE__*/Object.freeze({
+  hexToRgba: hexToRgba,
+  opacity: opacity,
+  shadeHex: shadeHex,
+  toRgb: toRgb,
+  transition: transition
+});
+
+var helpers = {
+  colors: colors
+};
+
 var sizeMap = {
   entries: [['xsmall', 1], ['small', 320], ['medium', 768], ['large', 1024], ['xlarge', 1366]],
   hash: {},
@@ -483,10 +552,6 @@ var ReThemeProvider = function ReThemeProvider(props) {
       _useState2 = _slicedToArray(_useState, 2),
       dimensions = _useState2[0],
       setDimensions = _useState2[1];
-  var _useState3 = useState(false),
-      _useState4 = _slicedToArray(_useState3, 2),
-      hasListener = _useState4[0],
-      setListener = _useState4[1];
   var onChange = function onChange(_ref) {
     var win = _ref.window;
     var width = win.width,
@@ -505,11 +570,8 @@ var ReThemeProvider = function ReThemeProvider(props) {
     });
   };
   useEffect(function () {
-    if (!hasListener) {
-      Dimensions.addEventListener("change", onChange);
-      addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
-      setListener(true);
-    }
+    Dimensions.addEventListener("change", onChange);
+    addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
     return function () {
       Dimensions.removeEventListener("change", onChange);
       removeThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme);
@@ -617,4 +679,4 @@ var useThemeFocus = hookFactory({
   off: 'blur'
 });
 
-export { ReThemeContext, ReThemeProvider, addThemeEvent, fireThemeEvent, getDefaultTheme, getMergeSizes, getSize, getSizeMap, removeThemeEvent, setDefaultTheme, setRNDimensions, setRNPlatform, setSizes, useDimensions, useTheme, useThemeActive, useThemeFocus, useThemeHover, withTheme };
+export { ReThemeContext, ReThemeProvider, addThemeEvent, fireThemeEvent, getDefaultTheme, getMergeSizes, getSize, getSizeMap, helpers, removeThemeEvent, setDefaultTheme, setRNDimensions, setRNPlatform, setSizes, useDimensions, useTheme, useThemeActive, useThemeFocus, useThemeHover, withTheme };

--- a/src/context/provider.js
+++ b/src/context/provider.js
@@ -41,11 +41,6 @@ export const ReThemeProvider = props => {
   const [ dimensions, setDimensions ] = useState(Dimensions.get("window"))
 
   /**
-   * Boolean to ensure we only add the event listeners once
-   */
-  const [ hasListener, setListener ] = useState(false)
-  
-  /**
    * onChange listener for when the screen size changes
    *
    * @param {Object} arguments.window - holds the size of the current window
@@ -76,12 +71,9 @@ export const ReThemeProvider = props => {
    */
   useEffect(() => {
 
-    if(!hasListener){
-      // Add the event listeners
-      Dimensions.addEventListener("change", onChange)
-      addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme)
-      setListener(true)
-    }
+    // Add the event listeners
+    Dimensions.addEventListener("change", onChange)
+    addThemeEvent(Constants.BUILD_EVENT, updateCurrentTheme)
 
     // Return a function to remove the event listeners
     return () => {

--- a/src/helpers/colors.js
+++ b/src/helpers/colors.js
@@ -1,0 +1,113 @@
+import { get, isObj, isArr, isStr, reduceObj } from 'jsutils'
+
+const convertToPercent = (num, percent) => parseInt(num * (100 + percent) / 100)
+const checkColorMax = num => num < 255 ? num : 255
+
+const convertToColor = (num, percent) => {
+  const asPercent = convertToPercent(num, percent)
+  const withMax = checkColorMax(asPercent)
+  const asStr = withMax.toString(16)
+  
+  return asStr.length == 1 ? `0${asStr}` : asStr
+}
+
+const mapOpacity = opacity => {
+  // Map opacity amounts by .5
+  for(let amount = 100; amount >= 0;  amount-=5)
+    opacity[`_${amount}`] = opacity((amount / 100).toFixed(2))
+
+  return opacity
+}
+
+/**
+ * Convert hex color to rgba
+ * @param  { string } hex - color to convert
+ *
+ * @param {number} opacity - from 0-1
+ * @return rgba as string
+ */
+export const hexToRgba = (hex, opacity, asObj) => {
+  if (!hex)
+    return console.warn('Can not convert hex to rgba', hex) || `rgba(255,255,255,0)`
+
+  hex = hex.indexOf('#') === 0 ? hex.replace('#', '') : hex
+  
+  opacity = opacity > 1 ? (opacity / 100).toFixed(4) : opacity
+  
+  const rgbaObj = {
+    r: parseInt(hex.substring(0, 2), 16),
+    g: parseInt(hex.substring(2, 4), 16),
+    b: parseInt(hex.substring(4, 6), 16),
+    a: !opacity && opacity !== 0 ? 1 : opacity
+  }
+
+  return asObj ? rgbaObj : toRgb(rgbaObj)
+}
+
+/**
+ * Convert a hex color to rgba setting the opacity to the passed in amount prop
+ * @param {number} amount - Opacity amount
+ * @param {string|Object} color - color to convert
+ *
+ * @return rgba as string
+ */
+export const opacity = mapOpacity((amount, color) => {
+  return isStr(color) && color.indexOf('#') === 0
+    ? hexToRgba(color, amount)
+    : isObj(color)
+      ? toRgb(color, amount)
+      : `rgba(${color || '0,0,0'}, ${amount})`
+})
+
+/**
+ * Shades a hex color based on the passed in percent
+ * @param {string} color - Hex color to shade
+ * @param {number} percent - amount to shared, can be positive or negitive
+ *
+ * @returns {string} - Shaded hex string
+ */
+export const shadeHex = (color, percent) => {
+  const rgba = hexToRgba(color, 1, true)
+
+  return "#" +
+    convertToColor(rgba.r, percent) +
+    convertToColor(rgba.g, percent) +
+    convertToColor(rgba.b, percent)
+}
+
+/**
+ * Convert { r: 0, g: 0, b:0, a: 0 } object to rgba() string
+ * @param {string|number|object} red - red color value or an object with r,g,b,a values
+ * @param {string|number} green - green color value
+ * @param {string|number} blue - blue color value
+ * @param {number|float} alpha - opacity - from 0-1
+ *
+ * @return {string} rgba string
+ */
+export const toRgb = (red, green, blue, alpha) => {
+  const obj = isObj(red) ? red : { r: red, g: green, b: blue, a: alpha }
+  obj.a = (!obj.a && obj.a !== 0) ? 1 : obj.a
+
+  return `rgba(${obj.r}, ${obj.g}, ${obj.b}, ${obj.a})`
+}
+
+/**
+ * Builds a CSS transition rule
+ * @param {Array} [props=[]] - CSS rules to have the transition applied to
+ * @param {number} [speed=250] - Speed of the transition
+ * @param {string} [timingFunc='ease'] - Type of transition animation to use
+ *
+ * @returns {string} - Built CSS transition rule
+ */
+export const transition = (props = [], speed = 250, timingFunc = 'ease') => {
+  return typeof props === 'string'
+    ? `${props} ${speed}ms ${timingFunc}`
+    : isArr(props)
+      ? props
+        .reduce((trans, prop) => {
+          trans.push(`${prop} ${speed}ms ${timingFunc}`)
+          return trans
+        }, [])
+        .join(', ')
+      : null
+}

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -1,0 +1,5 @@
+import * as colors from './colors'
+
+export const helpers = {
+  colors
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,2 +1,3 @@
 export * from './getTheme'
 export * from './joinTheme'
+export * from './helpers'

--- a/src/hooks/nativeThemeHook.js
+++ b/src/hooks/nativeThemeHook.js
@@ -1,5 +1,14 @@
-import { useRef, useState } from 'react'
-import { get } from 'jsutils'
+import { useRef, useState, useLayoutEffect } from 'react'
+import { get, jsonEqual } from 'jsutils'
+
+/**
+ * Checks it two passed in objects are equal pointers or equal as json strings
+ * @param {Object} obj1 - Object to check
+ * @param {Object} obj2 - Object to check
+ *
+ * @returns {boolean} - If objects are equal
+ */
+const checkEqual = (obj1, obj2) => obj1 === obj2 || jsonEqual(obj1, obj2)
 
 /**
  * Placeholder hook when on native device
@@ -16,6 +25,12 @@ export const nativeThemeHook = (offValue, onValue, options) => {
 
   // Set the default value
   const [ value, setValue ] = useState(offValue)
+
+  useLayoutEffect(() => {
+
+    !checkEqual(offValue, value) && setValue(value)
+
+  }, [ offValue, onValue ])
 
   // Return an array metching the same format as on web
   return [ hookRef, offValue, setValue ]

--- a/src/index.native.js
+++ b/src/index.native.js
@@ -8,6 +8,7 @@ import {
 } from './dimensions'
 import { setRNDimensions } from "ReDimensions"
 import { setRNPlatform } from "RePlatform"
+import { helpers } from "./helpers"
 
 import {
   addThemeEvent,
@@ -53,5 +54,8 @@ export {
   // Context Exports
   ReThemeContext,
   ReThemeProvider,
+
+  // Style Helpers
+  helpers
 
 }

--- a/src/index.web.js
+++ b/src/index.web.js
@@ -8,6 +8,7 @@ import {
 } from './dimensions'
 import { setRNDimensions } from "ReDimensions"
 import { setRNPlatform } from "RePlatform"
+import { helpers } from "./helpers"
 
 import {
   addThemeEvent,
@@ -53,5 +54,8 @@ export {
   // Context Exports
   ReThemeContext,
   ReThemeProvider,
+
+  // Style Helpers
+  helpers
 
 }


### PR DESCRIPTION
### Updates
* This Pull request should be tested with this [keg-components](https://github.com/simpleviewinc/keg-components/pull/6) pull request
* Fixed a bug in the context provider that was causing re-renders for any component that used the `withTheme` hoc or `useTheme` hook
* Added a number of helpers to the re-theme exports
  * Most of these are color helpers, but I can see more being added down the road

### To Test
* Pull down this branch, and  run the example app => `yarn app`
* Update the package.json of `keg-components` 
  * Change the devDependencies for re-theme to be =>
    `"re-theme": "git+https://github.com/simpleviewinc/re-theme.git#0c23eab9e8fe17a5bf8230965db30eec030c97b2",`
* Then run => `yarn sb`

