### PR TITLE
ZEN-231: Code Coverage Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ios/platform.sqlite
 
 # code coverage
 coverage/
+reports/
 
 # OSX
 #

--- a/package.json
+++ b/package.json
@@ -66,8 +66,9 @@
       "<rootDir>/src/**/__tests__/**/*.js?(x)"
     ],
     "collectCoverageFrom": [
-      "<rootDir>/src/index.js"
+      "src/**/*.{js,jsx,ts,tsx}"
     ],
+    "coverageDirectory": "coverage",
     "moduleFileExtensions": [
       "js",
       "json",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "dev": "yarn clean:build; rollup -c rollup.config.js -w",
     "app": "cd app; yarn start",
     "start": "yarn dev",
-    "test": "NODE_ENV=test jest --no-cache --verbose"
+    "test": "NODE_ENV=test jest --no-cache --verbose",
+    "test:reports": "yarn test --coverage && yarn view:reports",
+    "view:reports": "open reports/coverage/lcov-report/index.html"
   },
   "devDependencies": {
     "@babel/core": "7.5.5",
@@ -68,7 +70,7 @@
     "collectCoverageFrom": [
       "src/**/*.{js,jsx,ts,tsx}"
     ],
-    "coverageDirectory": "coverage",
+    "coverageDirectory": "reports/coverage",
     "moduleFileExtensions": [
       "js",
       "json",


### PR DESCRIPTION
**Ticket**: [ZEN-231](https://jira.simpleviewtools.com/browse/ZEN-231)

## Context

* For ZEN-231, I was reviewing the repositories and what code needed testing in each
* Code coverage wasn't working for re-theme

## Goal

* To get code coverage working

## Updates

* Updated the jest config object in `package.json` for code coverage

## Testing

* run `yarn test:reports` 
* verify that you see a table of code coverage appear in the terminal
* verify that coverage appears in a browser tab