### PR TITLE
Postinstall script for git assume-unchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build/esm/*"
   ],
   "scripts": {
+    "postinstall": "cd scripts && node postinstall.js",
     "build": "yarn clean:build; rollup -c rollup.config.js",
     "build:app": "cd app; yarn build",
     "clean:build": "rimraf build; mkdir build; mkdir build/cjs; mkdir build/esm; yarn copy:indexes",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "NODE_ENV=test jest --no-cache --verbose"
   },
   "devDependencies": {
+    "app-root-path": "3.0.0",
     "@babel/core": "7.5.5",
     "@babel/plugin-proposal-class-properties": "7.5.5",
     "@babel/preset-env": "7.5.5",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,7 +1,6 @@
 const util = require('util')
 const exec = util.promisify(require('child_process').exec)
-const path = require('path')
-const rootDir = path.join(__dirname, '../')
+const rootDir = require('app-root-path').path
 
 
 /**

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,23 @@
+const util = require('util')
+const exec = util.promisify(require('child_process').exec)
+const path = require('path')
+const rootDir = path.join(__dirname, '../')
+
+
+/**
+ * Setup git assume-unchange on all items in a folder
+ * @param {string} folderName - folder you want to set assume-unchange to
+ */
+const setupAssumeUnchange = async (folderName) => {
+  console.log(`-----git update assume-unchange folder: ${folderName}-----`)
+  try {
+    await exec(`cd ${rootDir} && git update-index --assume-unchanged ${folderName}/*/*`)
+
+  } catch (error) {
+    console.log(error)
+    console.log(`Try manually running 'git update-index --assume-unchanged ${folderName}/*/*'`)
+  }
+}
+
+setupAssumeUnchange('build')
+


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-176)

## Context

* currently repos include the builds/ folder in version control
* we need to update it to `assume-unchange` so we can build / modify it as many times locally and that it wont get committed.
* Github actions will handle all the builds/compilation now

## Goal

* Create a postinstall script that sets up `git assume-unchange` on the `/build` folder

## Updates

* `scripts/postinstall.js`
    * sets up `git assume-unchange` on the `/build` folder

## Testing

* Pull this branch
* run either `yarn install` || `yarn postinstall`
* Verify that you see the log `-----git update assume-unchange folder: build-----`
* modify the `/build` folder however you want
    * add/delete/edit
* Run `git status`
* verify that the folder `/build` isn't being tracked